### PR TITLE
Rectifies transliteration of stem + pattern (for conjugations)

### DIFF
--- a/pls_core/src/inflections/generators/conjugation.rs
+++ b/pls_core/src/inflections/generators/conjugation.rs
@@ -18,7 +18,7 @@ lazy_static! {
 #[derive(Serialize)]
 struct TenseViewModel {
     name: String,
-    inflections_list: Vec<Vec<String>>,
+    stemmed_inflections_list: Vec<Vec<String>>,
 }
 
 #[derive(Serialize)]
@@ -33,13 +33,12 @@ pub fn create_html_body(
     transliterate: fn(&str) -> Result<String, String>,
     exec_sql: impl Fn(&str) -> Result<Vec<Vec<Vec<String>>>, String>,
 ) -> Result<String, String> {
-    let tense_view_models = create_template_view_model(&table_name, transliterate, &exec_sql)?;
-
+    let tense_view_models =
+        create_template_view_model(&table_name, transliterate, &exec_sql, &stem)?;
     let vm = TemplateViewModel {
-        stem: &transliterate(stem)?,
+        stem: stem,
         tense_view_models,
     };
-
     let context = Context::from_serialize(&vm).map_err(|e| e.to_string())?;
     TEMPLATES
         .render("conjugation", &context)
@@ -50,6 +49,7 @@ fn create_template_view_model(
     table_name: &str,
     transliterate: fn(&str) -> Result<String, String>,
     exec_sql: impl Fn(&str) -> Result<Vec<Vec<Vec<String>>>, String>,
+    stem: &str,
 ) -> Result<Vec<TenseViewModel>, String> {
     let sql = r#"
         select * from _tense_values where name <> "";
@@ -69,7 +69,7 @@ fn create_template_view_model(
             continue;
         }
 
-        let mut inflections_list: Vec<Vec<String>> = Vec::new();
+        let mut stemmed_inflections_list: Vec<Vec<String>> = Vec::new();
         for p in values[1].iter().flatten() {
             for ar in values[2].iter().flatten() {
                 for n in values[3].iter().flatten() {
@@ -77,15 +77,20 @@ fn create_template_view_model(
                         r#"SELECT inflections FROM '{}' WHERE tense = '{}' AND person = '{}' AND actreflx = '{}' AND "number" = '{}'"#,
                         table_name, t, p, ar, n,
                     );
-                    let inflections = inflections::get_inflections(&sql, transliterate, &exec_sql);
-                    inflections_list.push(inflections);
+                    let stemmed_inflections = inflections::get_inflections_stemmed(
+                        &sql,
+                        &exec_sql,
+                        stem.to_string(),
+                        transliterate,
+                    )?;
+                    stemmed_inflections_list.push(stemmed_inflections);
                 }
             }
         }
 
         let view_model = TenseViewModel {
             name: t.to_owned(),
-            inflections_list,
+            stemmed_inflections_list,
         };
         view_models.push(view_model);
     }

--- a/pls_core/src/inflections/generators/conjugation.rs
+++ b/pls_core/src/inflections/generators/conjugation.rs
@@ -80,7 +80,7 @@ fn create_template_view_model(
                     let stemmed_inflections = inflections::get_inflections_stemmed(
                         &sql,
                         &exec_sql,
-                        stem.to_string(),
+                        &stem,
                         transliterate,
                     )?;
                     stemmed_inflections_list.push(stemmed_inflections);

--- a/pls_core/src/inflections/generators/conjugation.rs
+++ b/pls_core/src/inflections/generators/conjugation.rs
@@ -36,7 +36,7 @@ pub fn create_html_body(
     let tense_view_models =
         create_template_view_model(&table_name, transliterate, &exec_sql, &stem)?;
     let vm = TemplateViewModel {
-        stem: stem,
+        stem,
         tense_view_models,
     };
     let context = Context::from_serialize(&vm).map_err(|e| e.to_string())?;

--- a/pls_core/src/inflections/generators/templates/conjugation.html
+++ b/pls_core/src/inflections/generators/templates/conjugation.html
@@ -18,30 +18,30 @@
       <tr>
         <td><span class="pls-inflection-row-header">{{ tense_view_model.name }} 3rd</span></td>
         <td>
-          {% for inflection in tense_view_model.inflections_list.0 -%}
-          {% if inflection -%}
-          <div class="pls-inflection-inflected-word">{{ stem }}<span class="pls-inflection-inflected-word-suffix">{{ inflection }}</span></div>
+          {% for stemmed_inflection in tense_view_model.stemmed_inflections_list.0 -%}
+          {% if stemmed_inflection -%}
+          <div class="pls-inflection-inflected-word">{{ stemmed_inflection }}</div>
           {% endif -%}
           {% endfor -%}
         </td>
         <td>
-          {% for inflection in tense_view_model.inflections_list.1 -%}
-          {% if inflection -%}
-          <div class="pls-inflection-inflected-word">{{ stem }}<span class="pls-inflection-inflected-word-suffix">{{ inflection }}</span></div>
+          {% for stemmed_inflection in tense_view_model.stemmed_inflections_list.1 -%}
+          {% if stemmed_inflection -%}
+          <div class="pls-inflection-inflected-word">{{ stemmed_inflection }}</div>
           {% endif -%}
           {% endfor -%}
         </td>
         <td>
-          {% for inflection in tense_view_model.inflections_list.2 -%}
-          {% if inflection -%}
-          <div class="pls-inflection-inflected-word">{{ stem }}<span class="pls-inflection-inflected-word-suffix">{{ inflection }}</span></div>
+          {% for stemmed_inflection in tense_view_model.stemmed_inflections_list.2 -%}
+          {% if stemmed_inflection -%}
+          <div class="pls-inflection-inflected-word">{{ stemmed_inflection }}</div>
           {% endif -%}
           {% endfor -%}
         </td>
         <td>
-          {% for inflection in tense_view_model.inflections_list.3 -%}
-          {% if inflection -%}
-          <div class="pls-inflection-inflected-word">{{ stem }}<span class="pls-inflection-inflected-word-suffix">{{ inflection }}</span></div>
+          {% for stemmed_inflection in tense_view_model.stemmed_inflections_list.3 -%}
+          {% if stemmed_inflection -%}
+          <div class="pls-inflection-inflected-word">{{ stemmed_inflection }}</div>
           {% endif -%}
           {% endfor -%}
         </td>
@@ -49,30 +49,30 @@
       <tr>
         <td><span class="pls-inflection-row-header">{{ tense_view_model.name }} 2nd</span></td>
         <td>
-          {% for inflection in tense_view_model.inflections_list.4 -%}
-          {% if inflection -%}
-          <div class="pls-inflection-inflected-word">{{ stem }}<span class="pls-inflection-inflected-word-suffix">{{ inflection }}</span></div>
+          {% for stemmed_inflection in tense_view_model.stemmed_inflections_list.4 -%}
+          {% if stemmed_inflection -%}
+          <div class="pls-inflection-inflected-word">{{ stemmed_inflection }}</div>
           {% endif -%}
           {% endfor -%}
         </td>
         <td>
-          {% for inflection in tense_view_model.inflections_list.5 -%}
-          {% if inflection -%}
-          <div class="pls-inflection-inflected-word">{{ stem }}<span class="pls-inflection-inflected-word-suffix">{{ inflection }}</span></div>
+          {% for stemmed_inflection in tense_view_model.stemmed_inflections_list.5 -%}
+          {% if stemmed_inflection -%}
+          <div class="pls-inflection-inflected-word">{{ stemmed_inflection }}</div>
           {% endif -%}
           {% endfor -%}
         </td>
         <td>
-          {% for inflection in tense_view_model.inflections_list.6 -%}
-          {% if inflection -%}
-          <div class="pls-inflection-inflected-word">{{ stem }}<span class="pls-inflection-inflected-word-suffix">{{ inflection }}</span></div>
+          {% for stemmed_inflection in tense_view_model.stemmed_inflections_list.6 -%}
+          {% if stemmed_inflection -%}
+          <div class="pls-inflection-inflected-word">{{ stemmed_inflection }}</div>
           {% endif -%}
           {% endfor -%}
         </td>
         <td>
-          {% for inflection in tense_view_model.inflections_list.7 -%}
-          {% if inflection -%}
-          <div class="pls-inflection-inflected-word">{{ stem }}<span class="pls-inflection-inflected-word-suffix">{{ inflection }}</span></div>
+          {% for stemmed_inflection in tense_view_model.stemmed_inflections_list.7 -%}
+          {% if stemmed_inflection -%}
+          <div class="pls-inflection-inflected-word">{{ stemmed_inflection }}</div>
           {% endif -%}
           {% endfor -%}
         </td>
@@ -80,30 +80,30 @@
       <tr>
         <td><span class="pls-inflection-row-header">{{ tense_view_model.name }} 1st</span></td>
         <td>
-          {% for inflection in tense_view_model.inflections_list.8 -%}
-          {% if inflection -%}
-          <div class="pls-inflection-inflected-word">{{ stem }}<span class="pls-inflection-inflected-word-suffix">{{ inflection }}</span></div>
+          {% for stemmed_inflection in tense_view_model.stemmed_inflections_list.8 -%}
+          {% if stemmed_inflection -%}
+          <div class="pls-inflection-inflected-word">{{ stemmed_inflection }}</div>
           {% endif -%}
           {% endfor -%}
         </td>
         <td>
-          {% for inflection in tense_view_model.inflections_list.9 -%}
-          {% if inflection -%}
-          <div class="pls-inflection-inflected-word">{{ stem }}<span class="pls-inflection-inflected-word-suffix">{{ inflection }}</span></div>
+          {% for stemmed_inflection in tense_view_model.stemmed_inflections_list.9 -%}
+          {% if stemmed_inflection -%}
+          <div class="pls-inflection-inflected-word">{{ stemmed_inflection }}</div>
           {% endif -%}
           {% endfor -%}
         </td>
         <td>
-          {% for inflection in tense_view_model.inflections_list.10 -%}
-          {% if inflection -%}
-          <div class="pls-inflection-inflected-word">{{ stem }}<span class="pls-inflection-inflected-word-suffix">{{ inflection }}</span></div>
+          {% for stemmed_inflection in tense_view_model.stemmed_inflections_list.10 -%}
+          {% if stemmed_inflection -%}
+          <div class="pls-inflection-inflected-word">{{ stemmed_inflection }}</div>
           {% endif -%}
           {% endfor -%}
         </td>
         <td>
-          {% for inflection in tense_view_model.inflections_list.11 -%}
-          {% if inflection -%}
-          <div class="pls-inflection-inflected-word">{{ stem }}<span class="pls-inflection-inflected-word-suffix">{{ inflection }}</span></div>
+          {% for stemmed_inflection in tense_view_model.stemmed_inflections_list.11 -%}
+          {% if stemmed_inflection -%}
+          <div class="pls-inflection-inflected-word">{{ stemmed_inflection }}</div>
           {% endif -%}
           {% endfor -%}
         </td>

--- a/pls_core/src/inflections/mod.rs
+++ b/pls_core/src/inflections/mod.rs
@@ -261,3 +261,18 @@ fn get_inflections(
 
     inflections
 }
+
+pub fn get_inflections_stemmed(
+    sql: &str,
+    exec_sql: impl Fn(&str) -> Result<Vec<Vec<Vec<String>>>, String>,
+    stem: String,
+    transliterate: fn(&str) -> Result<String, String>,
+) -> Result<Vec<String>, String> {
+    let mut inflections = get_inflections(&sql, |s| Ok(s.to_string()), &exec_sql);
+    for inflection in inflections.iter_mut() {
+        if inflection.len() > 0 {
+            *inflection = transliterate(&(stem.to_owned() + inflection)).unwrap_or_else(|e| e);
+        }
+    }
+    Ok(inflections)
+}

--- a/pls_core/src/inflections/mod.rs
+++ b/pls_core/src/inflections/mod.rs
@@ -270,7 +270,7 @@ pub fn get_inflections_stemmed(
 ) -> Result<Vec<String>, String> {
     let mut inflections = get_inflections(&sql, |s| Ok(s.to_string()), &exec_sql);
     for inflection in inflections.iter_mut() {
-        if inflection.len() > 0 {
+        if !inflection.is_empty() {
             *inflection = transliterate(&(stem.to_owned() + inflection)).unwrap_or_else(|e| e);
         }
     }

--- a/pls_core/src/inflections/mod.rs
+++ b/pls_core/src/inflections/mod.rs
@@ -265,13 +265,14 @@ fn get_inflections(
 pub fn get_inflections_stemmed(
     sql: &str,
     exec_sql: impl Fn(&str) -> Result<Vec<Vec<Vec<String>>>, String>,
-    stem: String,
+    stem: &str,
     transliterate: fn(&str) -> Result<String, String>,
 ) -> Result<Vec<String>, String> {
     let mut inflections = get_inflections(&sql, |s| Ok(s.to_string()), &exec_sql);
     for inflection in inflections.iter_mut() {
         if !inflection.is_empty() {
-            *inflection = transliterate(&(stem.to_owned() + inflection)).unwrap_or_else(|e| e);
+            *inflection =
+                transliterate(&format!("{}{}", stem.to_owned(), inflection)).unwrap_or_else(|e| e);
         }
     }
     Ok(inflections)

--- a/test_app/src/snapshots/test_app__tests__inflection_tests__conjugation_1.snap
+++ b/test_app/src/snapshots/test_app__tests__inflection_tests__conjugation_1.snap
@@ -26,10 +26,10 @@ expression: html
       <tr>
         <td><span class="pls-inflection-row-header">pr 3rd</span></td>
         <td>
-          <div class="pls-inflection-inflected-word">ābādh<span class="pls-inflection-inflected-word-suffix">eti</span></div>
+          <div class="pls-inflection-inflected-word">ābādheti</div>
           </td>
         <td>
-          <div class="pls-inflection-inflected-word">ābādh<span class="pls-inflection-inflected-word-suffix">enti</span></div>
+          <div class="pls-inflection-inflected-word">ābādhenti</div>
           </td>
         <td>
           </td>
@@ -39,10 +39,10 @@ expression: html
       <tr>
         <td><span class="pls-inflection-row-header">pr 2nd</span></td>
         <td>
-          <div class="pls-inflection-inflected-word">ābādh<span class="pls-inflection-inflected-word-suffix">esi</span></div>
+          <div class="pls-inflection-inflected-word">ābādhesi</div>
           </td>
         <td>
-          <div class="pls-inflection-inflected-word">ābādh<span class="pls-inflection-inflected-word-suffix">etha</span></div>
+          <div class="pls-inflection-inflected-word">ābādhetha</div>
           </td>
         <td>
           </td>
@@ -52,10 +52,10 @@ expression: html
       <tr>
         <td><span class="pls-inflection-row-header">pr 1st</span></td>
         <td>
-          <div class="pls-inflection-inflected-word">ābādh<span class="pls-inflection-inflected-word-suffix">emi</span></div>
+          <div class="pls-inflection-inflected-word">ābādhemi</div>
           </td>
         <td>
-          <div class="pls-inflection-inflected-word">ābādh<span class="pls-inflection-inflected-word-suffix">ema</span></div>
+          <div class="pls-inflection-inflected-word">ābādhema</div>
           </td>
         <td>
           </td>
@@ -84,46 +84,46 @@ expression: html
       <tr>
         <td><span class="pls-inflection-row-header">imp 3rd</span></td>
         <td>
-          <div class="pls-inflection-inflected-word">ābādh<span class="pls-inflection-inflected-word-suffix">etu</span></div>
+          <div class="pls-inflection-inflected-word">ābādhetu</div>
           </td>
         <td>
-          <div class="pls-inflection-inflected-word">ābādh<span class="pls-inflection-inflected-word-suffix">entu</span></div>
+          <div class="pls-inflection-inflected-word">ābādhentu</div>
           </td>
         <td>
-          <div class="pls-inflection-inflected-word">ābādh<span class="pls-inflection-inflected-word-suffix">etaṃ</span></div>
+          <div class="pls-inflection-inflected-word">ābādhetaṃ</div>
           </td>
         <td>
-          <div class="pls-inflection-inflected-word">ābādh<span class="pls-inflection-inflected-word-suffix">entaṃ</span></div>
+          <div class="pls-inflection-inflected-word">ābādhentaṃ</div>
           </td>
       </tr>
       <tr>
         <td><span class="pls-inflection-row-header">imp 2nd</span></td>
         <td>
-          <div class="pls-inflection-inflected-word">ābādh<span class="pls-inflection-inflected-word-suffix">ehi</span></div>
+          <div class="pls-inflection-inflected-word">ābādhehi</div>
           </td>
         <td>
-          <div class="pls-inflection-inflected-word">ābādh<span class="pls-inflection-inflected-word-suffix">etha</span></div>
+          <div class="pls-inflection-inflected-word">ābādhetha</div>
           </td>
         <td>
-          <div class="pls-inflection-inflected-word">ābādh<span class="pls-inflection-inflected-word-suffix">essu</span></div>
+          <div class="pls-inflection-inflected-word">ābādhessu</div>
           </td>
         <td>
-          <div class="pls-inflection-inflected-word">ābādh<span class="pls-inflection-inflected-word-suffix">evho</span></div>
+          <div class="pls-inflection-inflected-word">ābādhevho</div>
           </td>
       </tr>
       <tr>
         <td><span class="pls-inflection-row-header">imp 1st</span></td>
         <td>
-          <div class="pls-inflection-inflected-word">ābādh<span class="pls-inflection-inflected-word-suffix">emi</span></div>
+          <div class="pls-inflection-inflected-word">ābādhemi</div>
           </td>
         <td>
-          <div class="pls-inflection-inflected-word">ābādh<span class="pls-inflection-inflected-word-suffix">ema</span></div>
+          <div class="pls-inflection-inflected-word">ābādhema</div>
           </td>
         <td>
-          <div class="pls-inflection-inflected-word">ābādh<span class="pls-inflection-inflected-word-suffix">e</span></div>
+          <div class="pls-inflection-inflected-word">ābādhe</div>
           </td>
         <td>
-          <div class="pls-inflection-inflected-word">ābādh<span class="pls-inflection-inflected-word-suffix">emase</span></div>
+          <div class="pls-inflection-inflected-word">ābādhemase</div>
           </td>
       </tr>
     </tbody>
@@ -148,54 +148,54 @@ expression: html
       <tr>
         <td><span class="pls-inflection-row-header">opt 3rd</span></td>
         <td>
-          <div class="pls-inflection-inflected-word">ābādh<span class="pls-inflection-inflected-word-suffix">eyya</span></div>
-          <div class="pls-inflection-inflected-word">ābādh<span class="pls-inflection-inflected-word-suffix">e</span></div>
+          <div class="pls-inflection-inflected-word">ābādheyya</div>
+          <div class="pls-inflection-inflected-word">ābādhe</div>
           </td>
         <td>
-          <div class="pls-inflection-inflected-word">ābādh<span class="pls-inflection-inflected-word-suffix">eyyuṃ</span></div>
+          <div class="pls-inflection-inflected-word">ābādheyyuṃ</div>
           </td>
         <td>
-          <div class="pls-inflection-inflected-word">ābādh<span class="pls-inflection-inflected-word-suffix">etha</span></div>
+          <div class="pls-inflection-inflected-word">ābādhetha</div>
           </td>
         <td>
-          <div class="pls-inflection-inflected-word">ābādh<span class="pls-inflection-inflected-word-suffix">eraṃ</span></div>
+          <div class="pls-inflection-inflected-word">ābādheraṃ</div>
           </td>
       </tr>
       <tr>
         <td><span class="pls-inflection-row-header">opt 2nd</span></td>
         <td>
-          <div class="pls-inflection-inflected-word">ābādh<span class="pls-inflection-inflected-word-suffix">eyyāsi</span></div>
-          <div class="pls-inflection-inflected-word">ābādh<span class="pls-inflection-inflected-word-suffix">e</span></div>
+          <div class="pls-inflection-inflected-word">ābādheyyāsi</div>
+          <div class="pls-inflection-inflected-word">ābādhe</div>
           </td>
         <td>
-          <div class="pls-inflection-inflected-word">ābādh<span class="pls-inflection-inflected-word-suffix">eyyātha</span></div>
-          <div class="pls-inflection-inflected-word">ābādh<span class="pls-inflection-inflected-word-suffix">etha</span></div>
+          <div class="pls-inflection-inflected-word">ābādheyyātha</div>
+          <div class="pls-inflection-inflected-word">ābādhetha</div>
           </td>
         <td>
-          <div class="pls-inflection-inflected-word">ābādh<span class="pls-inflection-inflected-word-suffix">etho</span></div>
+          <div class="pls-inflection-inflected-word">ābādhetho</div>
           </td>
         <td>
-          <div class="pls-inflection-inflected-word">ābādh<span class="pls-inflection-inflected-word-suffix">eyyavho</span></div>
-          <div class="pls-inflection-inflected-word">ābādh<span class="pls-inflection-inflected-word-suffix">eyyāvho</span></div>
+          <div class="pls-inflection-inflected-word">ābādheyyavho</div>
+          <div class="pls-inflection-inflected-word">ābādheyyāvho</div>
           </td>
       </tr>
       <tr>
         <td><span class="pls-inflection-row-header">opt 1st</span></td>
         <td>
-          <div class="pls-inflection-inflected-word">ābādh<span class="pls-inflection-inflected-word-suffix">eyyāmi</span></div>
-          <div class="pls-inflection-inflected-word">ābādh<span class="pls-inflection-inflected-word-suffix">eyyaṃ</span></div>
-          <div class="pls-inflection-inflected-word">ābādh<span class="pls-inflection-inflected-word-suffix">e</span></div>
+          <div class="pls-inflection-inflected-word">ābādheyyāmi</div>
+          <div class="pls-inflection-inflected-word">ābādheyyaṃ</div>
+          <div class="pls-inflection-inflected-word">ābādhe</div>
           </td>
         <td>
-          <div class="pls-inflection-inflected-word">ābādh<span class="pls-inflection-inflected-word-suffix">eyyāma</span></div>
-          <div class="pls-inflection-inflected-word">ābādh<span class="pls-inflection-inflected-word-suffix">ema</span></div>
-          <div class="pls-inflection-inflected-word">ābādh<span class="pls-inflection-inflected-word-suffix">emu</span></div>
+          <div class="pls-inflection-inflected-word">ābādheyyāma</div>
+          <div class="pls-inflection-inflected-word">ābādhema</div>
+          <div class="pls-inflection-inflected-word">ābādhemu</div>
           </td>
         <td>
-          <div class="pls-inflection-inflected-word">ābādh<span class="pls-inflection-inflected-word-suffix">eyyaṃ</span></div>
+          <div class="pls-inflection-inflected-word">ābādheyyaṃ</div>
           </td>
         <td>
-          <div class="pls-inflection-inflected-word">ābādh<span class="pls-inflection-inflected-word-suffix">eyyāmhe</span></div>
+          <div class="pls-inflection-inflected-word">ābādheyyāmhe</div>
           </td>
       </tr>
     </tbody>
@@ -220,46 +220,46 @@ expression: html
       <tr>
         <td><span class="pls-inflection-row-header">fut 3rd</span></td>
         <td>
-          <div class="pls-inflection-inflected-word">ābādh<span class="pls-inflection-inflected-word-suffix">essati</span></div>
+          <div class="pls-inflection-inflected-word">ābādhessati</div>
           </td>
         <td>
-          <div class="pls-inflection-inflected-word">ābādh<span class="pls-inflection-inflected-word-suffix">essanti</span></div>
+          <div class="pls-inflection-inflected-word">ābādhessanti</div>
           </td>
         <td>
-          <div class="pls-inflection-inflected-word">ābādh<span class="pls-inflection-inflected-word-suffix">essate</span></div>
+          <div class="pls-inflection-inflected-word">ābādhessate</div>
           </td>
         <td>
-          <div class="pls-inflection-inflected-word">ābādh<span class="pls-inflection-inflected-word-suffix">essante</span></div>
+          <div class="pls-inflection-inflected-word">ābādhessante</div>
           </td>
       </tr>
       <tr>
         <td><span class="pls-inflection-row-header">fut 2nd</span></td>
         <td>
-          <div class="pls-inflection-inflected-word">ābādh<span class="pls-inflection-inflected-word-suffix">essasi</span></div>
+          <div class="pls-inflection-inflected-word">ābādhessasi</div>
           </td>
         <td>
-          <div class="pls-inflection-inflected-word">ābādh<span class="pls-inflection-inflected-word-suffix">essatha</span></div>
+          <div class="pls-inflection-inflected-word">ābādhessatha</div>
           </td>
         <td>
-          <div class="pls-inflection-inflected-word">ābādh<span class="pls-inflection-inflected-word-suffix">essase</span></div>
+          <div class="pls-inflection-inflected-word">ābādhessase</div>
           </td>
         <td>
-          <div class="pls-inflection-inflected-word">ābādh<span class="pls-inflection-inflected-word-suffix">essavhe</span></div>
+          <div class="pls-inflection-inflected-word">ābādhessavhe</div>
           </td>
       </tr>
       <tr>
         <td><span class="pls-inflection-row-header">fut 1st</span></td>
         <td>
-          <div class="pls-inflection-inflected-word">ābādh<span class="pls-inflection-inflected-word-suffix">essāmi</span></div>
+          <div class="pls-inflection-inflected-word">ābādhessāmi</div>
           </td>
         <td>
-          <div class="pls-inflection-inflected-word">ābādh<span class="pls-inflection-inflected-word-suffix">essāma</span></div>
+          <div class="pls-inflection-inflected-word">ābādhessāma</div>
           </td>
         <td>
-          <div class="pls-inflection-inflected-word">ābādh<span class="pls-inflection-inflected-word-suffix">essaṃ</span></div>
+          <div class="pls-inflection-inflected-word">ābādhessaṃ</div>
           </td>
         <td>
-          <div class="pls-inflection-inflected-word">ābādh<span class="pls-inflection-inflected-word-suffix">essāmhe</span></div>
+          <div class="pls-inflection-inflected-word">ābādhessāmhe</div>
           </td>
       </tr>
     </tbody>


### PR DESCRIPTION
Partial Fix(conjugations only) for problem pointed out in the following feedback - ```आबाधेति / आबाध्एति    Dear programmer  here i  want suggest that the endings of the particular words and the verbs that are made here,  the vowel and ' the consonant are not connected ' the example   i showed above.  It should be like आबाध्एति > अबाधेति ( ābādh+e+ti = ābādheti).... it would be better if this could be fixed... With metta.......```