### PR TITLE
Fixes double spacing between PoS and Meaning

### DIFF
--- a/pls_core/src/alphabet.rs
+++ b/pls_core/src/alphabet.rs
@@ -9,22 +9,22 @@ use std::{convert::TryFrom, iter::Peekable};
 #[repr(usize)]
 pub enum PaliAlphabet {
     A,
-    AA,
+    Aa,
     I,
-    II,
+    Ii,
     U,
-    UU,
+    Uu,
     E,
     O, // vowels - 0-7
     K,
-    KH,
+    Kh,
     G,
-    GH,
+    Gh,
     QuoteN, // guttural - 8-12
     C,
-    CH,
+    Ch,
     J,
-    JH,
+    Jh,
     TildeN, // palatal - 13-17
     DotT,
     DotTH,
@@ -32,14 +32,14 @@ pub enum PaliAlphabet {
     DotDH,
     DotN, // retroflex cerebral - 18-22
     T,
-    TH,
+    Th,
     D,
-    DH,
+    Dh,
     N, // dental - 23-27
     P,
-    PH,
+    Ph,
     B,
-    BH,
+    Bh,
     M, // labial - 28-32
     Y,
     R,

--- a/pls_core/src/alphabet.rs
+++ b/pls_core/src/alphabet.rs
@@ -143,33 +143,33 @@ impl<'a> Iterator for CharacterTokenizer<'a> {
     fn next(&mut self) -> Option<Character> {
         match self.source.next() {
             Some('a') => Some(parse_singlechar_letter(PaliAlphabet::A)),
-            Some('ā') => Some(parse_singlechar_letter(PaliAlphabet::AA)),
+            Some('ā') => Some(parse_singlechar_letter(PaliAlphabet::Aa)),
             Some('i') => Some(parse_singlechar_letter(PaliAlphabet::I)),
-            Some('ī') => Some(parse_singlechar_letter(PaliAlphabet::II)),
+            Some('ī') => Some(parse_singlechar_letter(PaliAlphabet::Ii)),
             Some('u') => Some(parse_singlechar_letter(PaliAlphabet::U)),
-            Some('ū') => Some(parse_singlechar_letter(PaliAlphabet::UU)),
+            Some('ū') => Some(parse_singlechar_letter(PaliAlphabet::Uu)),
             Some('e') => Some(parse_singlechar_letter(PaliAlphabet::E)),
             Some('o') => Some(parse_singlechar_letter(PaliAlphabet::O)),
             Some('k') => Some(parse_multichar_letter(
                 &mut self.source,
                 PaliAlphabet::K,
-                PaliAlphabet::KH,
+                PaliAlphabet::Kh,
             )),
             Some('g') => Some(parse_multichar_letter(
                 &mut self.source,
                 PaliAlphabet::G,
-                PaliAlphabet::GH,
+                PaliAlphabet::Gh,
             )),
             Some('ṅ') => Some(parse_singlechar_letter(PaliAlphabet::QuoteN)),
             Some('c') => Some(parse_multichar_letter(
                 &mut self.source,
                 PaliAlphabet::C,
-                PaliAlphabet::CH,
+                PaliAlphabet::Ch,
             )),
             Some('j') => Some(parse_multichar_letter(
                 &mut self.source,
                 PaliAlphabet::J,
-                PaliAlphabet::JH,
+                PaliAlphabet::Jh,
             )),
             Some('ñ') => Some(parse_singlechar_letter(PaliAlphabet::TildeN)),
             Some('ṭ') => Some(parse_multichar_letter(
@@ -186,23 +186,23 @@ impl<'a> Iterator for CharacterTokenizer<'a> {
             Some('t') => Some(parse_multichar_letter(
                 &mut self.source,
                 PaliAlphabet::T,
-                PaliAlphabet::TH,
+                PaliAlphabet::Th,
             )),
             Some('d') => Some(parse_multichar_letter(
                 &mut self.source,
                 PaliAlphabet::D,
-                PaliAlphabet::DH,
+                PaliAlphabet::Dh,
             )),
             Some('n') => Some(parse_singlechar_letter(PaliAlphabet::N)),
             Some('p') => Some(parse_multichar_letter(
                 &mut self.source,
                 PaliAlphabet::P,
-                PaliAlphabet::PH,
+                PaliAlphabet::Ph,
             )),
             Some('b') => Some(parse_multichar_letter(
                 &mut self.source,
                 PaliAlphabet::B,
-                PaliAlphabet::BH,
+                PaliAlphabet::Bh,
             )),
             Some('m') => Some(parse_singlechar_letter(PaliAlphabet::M)),
             Some('y') => Some(parse_singlechar_letter(PaliAlphabet::Y)),
@@ -279,7 +279,7 @@ mod tests {
             chars,
             vec![
                 Character::Other('x'),
-                Character::Pali(PaliAlphabet::AA),
+                Character::Pali(PaliAlphabet::Aa),
                 Character::Other('1'),
                 Character::Pali(PaliAlphabet::B)
             ]

--- a/pls_core/src/alphabet.rs
+++ b/pls_core/src/alphabet.rs
@@ -27,9 +27,9 @@ pub enum PaliAlphabet {
     Jh,
     TildeN, // palatal - 13-17
     DotT,
-    DotTH,
+    DotTh,
     DotD,
-    DotDH,
+    DotDh,
     DotN, // retroflex cerebral - 18-22
     T,
     Th,
@@ -175,12 +175,12 @@ impl<'a> Iterator for CharacterTokenizer<'a> {
             Some('ṭ') => Some(parse_multichar_letter(
                 &mut self.source,
                 PaliAlphabet::DotT,
-                PaliAlphabet::DotTH,
+                PaliAlphabet::DotTh,
             )),
             Some('ḍ') => Some(parse_multichar_letter(
                 &mut self.source,
                 PaliAlphabet::DotD,
-                PaliAlphabet::DotDH,
+                PaliAlphabet::DotDh,
             )),
             Some('ṇ') => Some(parse_singlechar_letter(PaliAlphabet::DotN)),
             Some('t') => Some(parse_multichar_letter(

--- a/pls_core/src/inflections/snapshots/pls_core__inflections__tests__inflection_tests__conjugation_1_en.snap
+++ b/pls_core/src/inflections/snapshots/pls_core__inflections__tests__inflection_tests__conjugation_1_en.snap
@@ -8,8 +8,7 @@ expression: html
     <summary>
       <div class="pls-inflection-summary-word-info">^ābādheti$ &ndash; "eti pr" (like ^bhāveti$)</div>
       <div class="pls-inflection-summary-definition">
-        <span class="pls-inflection-summary-definition-pos">(pr)</span>&nbsp;
-        <span class="pls-inflection-summary-definition-meaning">oppresses, harasses</span>
+        <span class="pls-inflection-summary-definition-pos">(pr)</span> <span class="pls-inflection-summary-definition-meaning">oppresses, harasses</span>
       </div>
     </summary>
   </header>

--- a/pls_core/src/inflections/snapshots/pls_core__inflections__tests__inflection_tests__conjugation_1_xx.snap
+++ b/pls_core/src/inflections/snapshots/pls_core__inflections__tests__inflection_tests__conjugation_1_xx.snap
@@ -8,8 +8,7 @@ expression: html
     <summary>
       <div class="pls-inflection-summary-word-info">^ābādheti$ &ndash; "eti pr" (like ^bhāveti$)</div>
       <div class="pls-inflection-summary-definition">
-        <span class="pls-inflection-summary-definition-pos">(pr)</span>&nbsp;
-        <span class="pls-inflection-summary-definition-meaning">oppresses, harasses</span>
+        <span class="pls-inflection-summary-definition-pos">(pr)</span> <span class="pls-inflection-summary-definition-meaning">oppresses, harasses</span>
       </div>
     </summary>
   </header>

--- a/pls_core/src/inflections/snapshots/pls_core__inflections__tests__inflection_tests__declension_1_xx_.snap
+++ b/pls_core/src/inflections/snapshots/pls_core__inflections__tests__inflection_tests__declension_1_xx_.snap
@@ -8,8 +8,7 @@ expression: html
     <summary>
       <div class="pls-inflection-summary-word-info">^vassūpanāyikā$ &ndash; "ā fem" (like ^vanitā$)</div>
       <div class="pls-inflection-summary-definition">
-        <span class="pls-inflection-summary-definition-pos">(f)</span>&nbsp;
-        <span class="pls-inflection-summary-definition-meaning">(vinaya) rains retreat entry</span>
+        <span class="pls-inflection-summary-definition-pos">(f)</span> <span class="pls-inflection-summary-definition-meaning">(vinaya) rains retreat entry</span>
       </div>
     </summary>
   </header>

--- a/pls_core/src/inflections/snapshots/pls_core__inflections__tests__inflection_tests__declension_2_irreg_xx.snap
+++ b/pls_core/src/inflections/snapshots/pls_core__inflections__tests__inflection_tests__declension_2_irreg_xx.snap
@@ -8,8 +8,7 @@ expression: html
     <summary>
       <div class="pls-inflection-summary-word-info">^kamma 1$ &ndash; "kamma nt" (irregular)</div>
       <div class="pls-inflection-summary-definition">
-        <span class="pls-inflection-summary-definition-pos">(nt)</span>&nbsp;
-        <span class="pls-inflection-summary-definition-meaning">action, deed, doing</span>
+        <span class="pls-inflection-summary-definition-pos">(nt)</span> <span class="pls-inflection-summary-definition-meaning">action, deed, doing</span>
       </div>
     </summary>
   </header>

--- a/pls_core/src/inflections/snapshots/pls_core__inflections__tests__inflection_tests__declension_3_ind_xx.snap
+++ b/pls_core/src/inflections/snapshots/pls_core__inflections__tests__inflection_tests__declension_3_ind_xx.snap
@@ -8,8 +8,7 @@ expression: html
     <summary>
       <div class="pls-inflection-summary-word-info">^kāmaṃ 3$ (indeclinable)</div>
       <div class="pls-inflection-summary-definition">
-        <span class="pls-inflection-summary-definition-pos">(ind)</span>&nbsp;
-        <span class="pls-inflection-summary-definition-meaning">indeed, surely</span>
+        <span class="pls-inflection-summary-definition-pos">(ind)</span> <span class="pls-inflection-summary-definition-meaning">indeed, surely</span>
       </div>
     </summary>
   </header>

--- a/pls_core/src/inflections/snapshots/pls_core__inflections__tests__inflection_tests__declension_4_pron_1st_xx.snap
+++ b/pls_core/src/inflections/snapshots/pls_core__inflections__tests__inflection_tests__declension_4_pron_1st_xx.snap
@@ -8,8 +8,7 @@ expression: html
     <summary>
       <div class="pls-inflection-summary-word-info">^maṃ$ &ndash; "ahaṃ pron 1st" (irregular)</div>
       <div class="pls-inflection-summary-definition">
-        <span class="pls-inflection-summary-definition-pos">(pron)</span>&nbsp;
-        <span class="pls-inflection-summary-definition-meaning">me (object)</span>
+        <span class="pls-inflection-summary-definition-pos">(pron)</span> <span class="pls-inflection-summary-definition-meaning">me (object)</span>
       </div>
     </summary>
   </header>

--- a/pls_core/src/inflections/snapshots/pls_core__inflections__tests__inflection_tests__declension_4_pron_2nd_xx.snap
+++ b/pls_core/src/inflections/snapshots/pls_core__inflections__tests__inflection_tests__declension_4_pron_2nd_xx.snap
@@ -8,8 +8,7 @@ expression: html
     <summary>
       <div class="pls-inflection-summary-word-info">^taṃ 3$ &ndash; "tvaṃ pron 2nd" (irregular)</div>
       <div class="pls-inflection-summary-definition">
-        <span class="pls-inflection-summary-definition-pos">(pron)</span>&nbsp;
-        <span class="pls-inflection-summary-definition-meaning">you (object)</span>
+        <span class="pls-inflection-summary-definition-pos">(pron)</span> <span class="pls-inflection-summary-definition-meaning">you (object)</span>
       </div>
     </summary>
   </header>

--- a/pls_core/src/inflections/snapshots/pls_core__inflections__tests__inflection_tests__declension_4_pron_dual_xx.snap
+++ b/pls_core/src/inflections/snapshots/pls_core__inflections__tests__inflection_tests__declension_4_pron_dual_xx.snap
@@ -8,8 +8,7 @@ expression: html
     <summary>
       <div class="pls-inflection-summary-word-info">^ubha$ &ndash; "ubha pron dual" (irregular)</div>
       <div class="pls-inflection-summary-definition">
-        <span class="pls-inflection-summary-definition-pos">(pron)</span>&nbsp;
-        <span class="pls-inflection-summary-definition-meaning">both</span>
+        <span class="pls-inflection-summary-definition-pos">(pron)</span> <span class="pls-inflection-summary-definition-meaning">both</span>
       </div>
     </summary>
   </header>

--- a/pls_core/src/inflections/snapshots/pls_core__inflections__tests__inflection_tests__declension_5_only_x_gender_xx.snap
+++ b/pls_core/src/inflections/snapshots/pls_core__inflections__tests__inflection_tests__declension_5_only_x_gender_xx.snap
@@ -8,8 +8,7 @@ expression: html
     <summary>
       <div class="pls-inflection-summary-word-info">^pañca$ &ndash; "a1 card" (like ^pañca$)</div>
       <div class="pls-inflection-summary-definition">
-        <span class="pls-inflection-summary-definition-pos">(card)</span>&nbsp;
-        <span class="pls-inflection-summary-definition-meaning">five (5)</span>
+        <span class="pls-inflection-summary-definition-pos">(card)</span> <span class="pls-inflection-summary-definition-meaning">five (5)</span>
       </div>
     </summary>
   </header>

--- a/pls_core/src/inflections/templates/output.html
+++ b/pls_core/src/inflections/templates/output.html
@@ -7,8 +7,7 @@
       <div class="pls-inflection-summary-word-info">{{ pali1 }} ({{ like }})</div>
       {% endif -%}
       <div class="pls-inflection-summary-definition">
-        <span class="pls-inflection-summary-definition-pos">({{ pos }})</span>&nbsp;
-        <span class="pls-inflection-summary-definition-meaning">{{ meaning }}</span>
+        <span class="pls-inflection-summary-definition-pos">({{ pos }})</span> <span class="pls-inflection-summary-definition-meaning">{{ meaning }}</span>
       </div>
     </summary>
   </header>

--- a/test_app/src/main.rs
+++ b/test_app/src/main.rs
@@ -40,8 +40,8 @@ fn exec_sql(sql: &str) -> Result<String, String> {
 
 fn main() -> Result<(), String> {
     println!("{:?}", pls_core::alphabet::PALI_ALPHABET_ROMAN);
-    let x = pls_core::alphabet::PaliAlphabet::AA;
-    println!("ā > bh? {:#?}", x > pls_core::alphabet::PaliAlphabet::BH);
+    let x = pls_core::alphabet::PaliAlphabet::Aa;
+    println!("ā > bh? {:#?}", x > pls_core::alphabet::PaliAlphabet::Bh);
 
     let html = pls_core::inflections::generate_inflection_table(
         "kāmaṃ 3",


### PR DESCRIPTION
Deals with item in [this](https://github.com/digitalpalitools/web-ui/issues/7) issue -
> remove double space between (pos) and (meaning) . 