### PR TITLE
Changes formatting of inflection summary. 

### DIFF
--- a/pls_core/src/inflections/mod.rs
+++ b/pls_core/src/inflections/mod.rs
@@ -109,9 +109,17 @@ fn get_pali1_metadata(pali1: &str, host: &dyn PlsInflectionsHost) -> Result<Pali
 
         pm.inflection_class = inflection_class_from_str(inflection_class);
         pm.like = if !like.is_empty() {
-            format!("like {}", host.transliterate(like)?)
+            format!(
+                "{} like {}",
+                if inflection_class == "verb" {
+                    "conjugation"
+                } else {
+                    "declension"
+                },
+                host.transliterate(like)?
+            )
         } else {
-            "irregular".to_string()
+            "irreg".to_string()
         };
     } else if stem.eq("-") {
         pm.inflection_class = InflectionClass::Indeclinable;

--- a/pls_core/src/inflections/mod.rs
+++ b/pls_core/src/inflections/mod.rs
@@ -134,15 +134,7 @@ fn get_pali1_metadata(pali1: &str, host: &dyn PlsInflectionsHost) -> Result<Pali
 
         pm.inflection_class = inflection_class_from_str(inflection_class);
         pm.like = if !like.is_empty() {
-            format!(
-                "{} like {}",
-                if inflection_class == "verb" {
-                    "conjugation"
-                } else {
-                    "declension"
-                },
-                host.transliterate(like)?
-            )
+            format!("like {}", host.transliterate(like)?)
         } else {
             "irreg".to_string()
         };

--- a/pls_core/src/inflections/snapshots/pls_core__inflections__tests__inflection_tests__conjugation_1_en.snap
+++ b/pls_core/src/inflections/snapshots/pls_core__inflections__tests__inflection_tests__conjugation_1_en.snap
@@ -6,8 +6,11 @@ expression: html
 <div class="pls-inflection-root">
   <header class="pls-inflection-header">
     <summary>
-      <div class="pls-inflection-summary-word-info">^ābādheti$ "eti pr" conjugation like ^bhāveti$</div>
-      </summary>
+      <div class="pls-inflection-summary-word-info">^ābādheti$ "eti pr" like ^bhāveti$</div>
+      <div class="pls-inflection-summary-definition">
+        <span class="pls-inflection-summary-definition-pos">(pr)</span> <span class="pls-inflection-summary-definition-meaning">oppresses, harasses</span>
+      </div>
+    </summary>
   </header>
 <table class="pls-inflection-table pls-inflection-type-conjugation">
     <thead>

--- a/pls_core/src/inflections/snapshots/pls_core__inflections__tests__inflection_tests__conjugation_1_en.snap
+++ b/pls_core/src/inflections/snapshots/pls_core__inflections__tests__inflection_tests__conjugation_1_en.snap
@@ -6,11 +6,8 @@ expression: html
 <div class="pls-inflection-root">
   <header class="pls-inflection-header">
     <summary>
-      <div class="pls-inflection-summary-word-info">^ābādheti$ &ndash; "eti pr" (like ^bhāveti$)</div>
-      <div class="pls-inflection-summary-definition">
-        <span class="pls-inflection-summary-definition-pos">(pr)</span> <span class="pls-inflection-summary-definition-meaning">oppresses, harasses</span>
-      </div>
-    </summary>
+      <div class="pls-inflection-summary-word-info">^ābādheti$ "eti pr" conjugation like ^bhāveti$</div>
+      </summary>
   </header>
 <table class="pls-inflection-table pls-inflection-type-conjugation">
     <thead>

--- a/pls_core/src/inflections/snapshots/pls_core__inflections__tests__inflection_tests__conjugation_1_xx.snap
+++ b/pls_core/src/inflections/snapshots/pls_core__inflections__tests__inflection_tests__conjugation_1_xx.snap
@@ -6,8 +6,11 @@ expression: html
 <div class="pls-inflection-root">
   <header class="pls-inflection-header">
     <summary>
-      <div class="pls-inflection-summary-word-info">^ābādheti$ "eti pr" conjugation like ^bhāveti$</div>
-      </summary>
+      <div class="pls-inflection-summary-word-info">^ābādheti$ "eti pr" like ^bhāveti$</div>
+      <div class="pls-inflection-summary-definition">
+        <span class="pls-inflection-summary-definition-pos">(pr)</span> <span class="pls-inflection-summary-definition-meaning">oppresses, harasses</span>
+      </div>
+    </summary>
   </header>
 <table class="pls-inflection-table pls-inflection-type-conjugation">
     <thead>

--- a/pls_core/src/inflections/snapshots/pls_core__inflections__tests__inflection_tests__conjugation_1_xx.snap
+++ b/pls_core/src/inflections/snapshots/pls_core__inflections__tests__inflection_tests__conjugation_1_xx.snap
@@ -6,11 +6,8 @@ expression: html
 <div class="pls-inflection-root">
   <header class="pls-inflection-header">
     <summary>
-      <div class="pls-inflection-summary-word-info">^ābādheti$ &ndash; "eti pr" (like ^bhāveti$)</div>
-      <div class="pls-inflection-summary-definition">
-        <span class="pls-inflection-summary-definition-pos">(pr)</span> <span class="pls-inflection-summary-definition-meaning">oppresses, harasses</span>
-      </div>
-    </summary>
+      <div class="pls-inflection-summary-word-info">^ābādheti$ "eti pr" conjugation like ^bhāveti$</div>
+      </summary>
   </header>
 <table class="pls-inflection-table pls-inflection-type-conjugation">
     <thead>

--- a/pls_core/src/inflections/snapshots/pls_core__inflections__tests__inflection_tests__declension_1_xx_.snap
+++ b/pls_core/src/inflections/snapshots/pls_core__inflections__tests__inflection_tests__declension_1_xx_.snap
@@ -6,8 +6,11 @@ expression: html
 <div class="pls-inflection-root">
   <header class="pls-inflection-header">
     <summary>
-      <div class="pls-inflection-summary-word-info">^vassūpanāyikā$ "ā fem" declension like ^vanitā$</div>
-      </summary>
+      <div class="pls-inflection-summary-word-info">^vassūpanāyikā$ "ā fem" like ^vanitā$</div>
+      <div class="pls-inflection-summary-definition">
+        <span class="pls-inflection-summary-definition-pos">(f)</span> <span class="pls-inflection-summary-definition-meaning">(vinaya) rains retreat entry</span>
+      </div>
+    </summary>
   </header>
 <table class="pls-inflection-table pls-inflection-type-declension">
   <thead>

--- a/pls_core/src/inflections/snapshots/pls_core__inflections__tests__inflection_tests__declension_1_xx_.snap
+++ b/pls_core/src/inflections/snapshots/pls_core__inflections__tests__inflection_tests__declension_1_xx_.snap
@@ -6,11 +6,8 @@ expression: html
 <div class="pls-inflection-root">
   <header class="pls-inflection-header">
     <summary>
-      <div class="pls-inflection-summary-word-info">^vassūpanāyikā$ &ndash; "ā fem" (like ^vanitā$)</div>
-      <div class="pls-inflection-summary-definition">
-        <span class="pls-inflection-summary-definition-pos">(f)</span> <span class="pls-inflection-summary-definition-meaning">(vinaya) rains retreat entry</span>
-      </div>
-    </summary>
+      <div class="pls-inflection-summary-word-info">^vassūpanāyikā$ "ā fem" declension like ^vanitā$</div>
+      </summary>
   </header>
 <table class="pls-inflection-table pls-inflection-type-declension">
   <thead>

--- a/pls_core/src/inflections/snapshots/pls_core__inflections__tests__inflection_tests__declension_2_irreg_xx.snap
+++ b/pls_core/src/inflections/snapshots/pls_core__inflections__tests__inflection_tests__declension_2_irreg_xx.snap
@@ -7,7 +7,10 @@ expression: html
   <header class="pls-inflection-header">
     <summary>
       <div class="pls-inflection-summary-word-info">^kamma 1$ "kamma nt" irreg</div>
-      </summary>
+      <div class="pls-inflection-summary-definition">
+        <span class="pls-inflection-summary-definition-pos">(nt)</span> <span class="pls-inflection-summary-definition-meaning">action, deed, doing</span>
+      </div>
+    </summary>
   </header>
 <table class="pls-inflection-table pls-inflection-type-declension">
   <thead>

--- a/pls_core/src/inflections/snapshots/pls_core__inflections__tests__inflection_tests__declension_2_irreg_xx.snap
+++ b/pls_core/src/inflections/snapshots/pls_core__inflections__tests__inflection_tests__declension_2_irreg_xx.snap
@@ -6,11 +6,8 @@ expression: html
 <div class="pls-inflection-root">
   <header class="pls-inflection-header">
     <summary>
-      <div class="pls-inflection-summary-word-info">^kamma 1$ &ndash; "kamma nt" (irregular)</div>
-      <div class="pls-inflection-summary-definition">
-        <span class="pls-inflection-summary-definition-pos">(nt)</span> <span class="pls-inflection-summary-definition-meaning">action, deed, doing</span>
-      </div>
-    </summary>
+      <div class="pls-inflection-summary-word-info">^kamma 1$ "kamma nt" irreg</div>
+      </summary>
   </header>
 <table class="pls-inflection-table pls-inflection-type-declension">
   <thead>

--- a/pls_core/src/inflections/snapshots/pls_core__inflections__tests__inflection_tests__declension_3_ind_xx.snap
+++ b/pls_core/src/inflections/snapshots/pls_core__inflections__tests__inflection_tests__declension_3_ind_xx.snap
@@ -6,11 +6,8 @@ expression: html
 <div class="pls-inflection-root">
   <header class="pls-inflection-header">
     <summary>
-      <div class="pls-inflection-summary-word-info">^kāmaṃ 3$ (indeclinable)</div>
-      <div class="pls-inflection-summary-definition">
-        <span class="pls-inflection-summary-definition-pos">(ind)</span> <span class="pls-inflection-summary-definition-meaning">indeed, surely</span>
-      </div>
-    </summary>
+      <div class="pls-inflection-summary-word-info">^kāmaṃ 3$ indeclinable</div>
+      </summary>
   </header>
 <table class="pls-inflection-table pls-inflection-type-indeclinable">
   <tbody>

--- a/pls_core/src/inflections/snapshots/pls_core__inflections__tests__inflection_tests__declension_3_ind_xx.snap
+++ b/pls_core/src/inflections/snapshots/pls_core__inflections__tests__inflection_tests__declension_3_ind_xx.snap
@@ -7,7 +7,10 @@ expression: html
   <header class="pls-inflection-header">
     <summary>
       <div class="pls-inflection-summary-word-info">^kāmaṃ 3$ indeclinable</div>
-      </summary>
+      <div class="pls-inflection-summary-definition">
+        <span class="pls-inflection-summary-definition-pos">(ind)</span> <span class="pls-inflection-summary-definition-meaning">indeed, surely</span>
+      </div>
+    </summary>
   </header>
 <table class="pls-inflection-table pls-inflection-type-indeclinable">
   <tbody>

--- a/pls_core/src/inflections/snapshots/pls_core__inflections__tests__inflection_tests__declension_4_pron_1st_xx.snap
+++ b/pls_core/src/inflections/snapshots/pls_core__inflections__tests__inflection_tests__declension_4_pron_1st_xx.snap
@@ -7,7 +7,10 @@ expression: html
   <header class="pls-inflection-header">
     <summary>
       <div class="pls-inflection-summary-word-info">^maṃ$ "ahaṃ pron 1st" irreg</div>
-      </summary>
+      <div class="pls-inflection-summary-definition">
+        <span class="pls-inflection-summary-definition-pos">(pron)</span> <span class="pls-inflection-summary-definition-meaning">me (object)</span>
+      </div>
+    </summary>
   </header>
 <table class="pls-inflection-table pls-inflection-type-declension">
   <thead>

--- a/pls_core/src/inflections/snapshots/pls_core__inflections__tests__inflection_tests__declension_4_pron_1st_xx.snap
+++ b/pls_core/src/inflections/snapshots/pls_core__inflections__tests__inflection_tests__declension_4_pron_1st_xx.snap
@@ -6,11 +6,8 @@ expression: html
 <div class="pls-inflection-root">
   <header class="pls-inflection-header">
     <summary>
-      <div class="pls-inflection-summary-word-info">^maṃ$ &ndash; "ahaṃ pron 1st" (irregular)</div>
-      <div class="pls-inflection-summary-definition">
-        <span class="pls-inflection-summary-definition-pos">(pron)</span> <span class="pls-inflection-summary-definition-meaning">me (object)</span>
-      </div>
-    </summary>
+      <div class="pls-inflection-summary-word-info">^maṃ$ "ahaṃ pron 1st" irreg</div>
+      </summary>
   </header>
 <table class="pls-inflection-table pls-inflection-type-declension">
   <thead>

--- a/pls_core/src/inflections/snapshots/pls_core__inflections__tests__inflection_tests__declension_4_pron_2nd_xx.snap
+++ b/pls_core/src/inflections/snapshots/pls_core__inflections__tests__inflection_tests__declension_4_pron_2nd_xx.snap
@@ -6,11 +6,8 @@ expression: html
 <div class="pls-inflection-root">
   <header class="pls-inflection-header">
     <summary>
-      <div class="pls-inflection-summary-word-info">^taṃ 3$ &ndash; "tvaṃ pron 2nd" (irregular)</div>
-      <div class="pls-inflection-summary-definition">
-        <span class="pls-inflection-summary-definition-pos">(pron)</span> <span class="pls-inflection-summary-definition-meaning">you (object)</span>
-      </div>
-    </summary>
+      <div class="pls-inflection-summary-word-info">^taṃ 3$ "tvaṃ pron 2nd" irreg</div>
+      </summary>
   </header>
 <table class="pls-inflection-table pls-inflection-type-declension">
   <thead>

--- a/pls_core/src/inflections/snapshots/pls_core__inflections__tests__inflection_tests__declension_4_pron_2nd_xx.snap
+++ b/pls_core/src/inflections/snapshots/pls_core__inflections__tests__inflection_tests__declension_4_pron_2nd_xx.snap
@@ -7,7 +7,10 @@ expression: html
   <header class="pls-inflection-header">
     <summary>
       <div class="pls-inflection-summary-word-info">^taṃ 3$ "tvaṃ pron 2nd" irreg</div>
-      </summary>
+      <div class="pls-inflection-summary-definition">
+        <span class="pls-inflection-summary-definition-pos">(pron)</span> <span class="pls-inflection-summary-definition-meaning">you (object)</span>
+      </div>
+    </summary>
   </header>
 <table class="pls-inflection-table pls-inflection-type-declension">
   <thead>

--- a/pls_core/src/inflections/snapshots/pls_core__inflections__tests__inflection_tests__declension_4_pron_dual_xx.snap
+++ b/pls_core/src/inflections/snapshots/pls_core__inflections__tests__inflection_tests__declension_4_pron_dual_xx.snap
@@ -6,11 +6,8 @@ expression: html
 <div class="pls-inflection-root">
   <header class="pls-inflection-header">
     <summary>
-      <div class="pls-inflection-summary-word-info">^ubha$ &ndash; "ubha pron dual" (irregular)</div>
-      <div class="pls-inflection-summary-definition">
-        <span class="pls-inflection-summary-definition-pos">(pron)</span> <span class="pls-inflection-summary-definition-meaning">both</span>
-      </div>
-    </summary>
+      <div class="pls-inflection-summary-word-info">^ubha$ "ubha pron dual" irreg</div>
+      </summary>
   </header>
 <table class="pls-inflection-table pls-inflection-type-declension">
   <thead>

--- a/pls_core/src/inflections/snapshots/pls_core__inflections__tests__inflection_tests__declension_4_pron_dual_xx.snap
+++ b/pls_core/src/inflections/snapshots/pls_core__inflections__tests__inflection_tests__declension_4_pron_dual_xx.snap
@@ -7,7 +7,10 @@ expression: html
   <header class="pls-inflection-header">
     <summary>
       <div class="pls-inflection-summary-word-info">^ubha$ "ubha pron dual" irreg</div>
-      </summary>
+      <div class="pls-inflection-summary-definition">
+        <span class="pls-inflection-summary-definition-pos">(pron)</span> <span class="pls-inflection-summary-definition-meaning">both</span>
+      </div>
+    </summary>
   </header>
 <table class="pls-inflection-table pls-inflection-type-declension">
   <thead>

--- a/pls_core/src/inflections/snapshots/pls_core__inflections__tests__inflection_tests__declension_5_only_x_gender_xx.snap
+++ b/pls_core/src/inflections/snapshots/pls_core__inflections__tests__inflection_tests__declension_5_only_x_gender_xx.snap
@@ -6,8 +6,11 @@ expression: html
 <div class="pls-inflection-root">
   <header class="pls-inflection-header">
     <summary>
-      <div class="pls-inflection-summary-word-info">^pañca$ "a1 card" declension like ^pañca$</div>
-      </summary>
+      <div class="pls-inflection-summary-word-info">^pañca$ "a1 card" like ^pañca$</div>
+      <div class="pls-inflection-summary-definition">
+        <span class="pls-inflection-summary-definition-pos">(card)</span> <span class="pls-inflection-summary-definition-meaning">five (5)</span>
+      </div>
+    </summary>
   </header>
 <table class="pls-inflection-table pls-inflection-type-declension">
   <thead>

--- a/pls_core/src/inflections/snapshots/pls_core__inflections__tests__inflection_tests__declension_5_only_x_gender_xx.snap
+++ b/pls_core/src/inflections/snapshots/pls_core__inflections__tests__inflection_tests__declension_5_only_x_gender_xx.snap
@@ -6,11 +6,8 @@ expression: html
 <div class="pls-inflection-root">
   <header class="pls-inflection-header">
     <summary>
-      <div class="pls-inflection-summary-word-info">^pañca$ &ndash; "a1 card" (like ^pañca$)</div>
-      <div class="pls-inflection-summary-definition">
-        <span class="pls-inflection-summary-definition-pos">(card)</span> <span class="pls-inflection-summary-definition-meaning">five (5)</span>
-      </div>
-    </summary>
+      <div class="pls-inflection-summary-word-info">^pañca$ "a1 card" declension like ^pañca$</div>
+      </summary>
   </header>
 <table class="pls-inflection-table pls-inflection-type-declension">
   <thead>

--- a/pls_core/src/inflections/templates/output.html
+++ b/pls_core/src/inflections/templates/output.html
@@ -2,13 +2,10 @@
   <header class="pls-inflection-header">
     <summary>
       {% if pattern -%}
-      <div class="pls-inflection-summary-word-info">{{ pali1 }} &ndash; "{{ pattern }}" ({{ like }})</div>
+      <div class="pls-inflection-summary-word-info">{{ pali1 }} "{{ pattern }}" {{ like }}</div>
       {% else -%}
-      <div class="pls-inflection-summary-word-info">{{ pali1 }} ({{ like }})</div>
+      <div class="pls-inflection-summary-word-info">{{ pali1 }} {{ like }}</div>
       {% endif -%}
-      <div class="pls-inflection-summary-definition">
-        <span class="pls-inflection-summary-definition-pos">({{ pos }})</span> <span class="pls-inflection-summary-definition-meaning">{{ meaning }}</span>
-      </div>
     </summary>
   </header>
 {{ body }}

--- a/pls_core/src/inflections/templates/output.html
+++ b/pls_core/src/inflections/templates/output.html
@@ -6,6 +6,9 @@
       {% else -%}
       <div class="pls-inflection-summary-word-info">{{ pali1 }} {{ like }}</div>
       {% endif -%}
+      <div class="pls-inflection-summary-definition">
+        <span class="pls-inflection-summary-definition-pos">({{ pos }})</span> <span class="pls-inflection-summary-definition-meaning">{{ meaning }}</span>
+      </div>
     </summary>
   </header>
 {{ body }}


### PR DESCRIPTION
Item from https://github.com/digitalpalitools/web-ui/issues/7 -
> line 1 syntax: pañña "a adj" like dīgha
 line 1 syntax for irreg: addasa 1 "addasa aor" irreg
 delete line 2 entirely - it is currently duplicated 3 times in each entry
 table can follow immediately afterwards