### PR TITLE
Changes alphabetical order for sorting. (adds space to list of Pāli alphabets)

### DIFF
--- a/pls_core/src/alphabet.rs
+++ b/pls_core/src/alphabet.rs
@@ -343,10 +343,10 @@ mod tests {
 
         #[test]
         fn fixup_compound_letters_with_compound_letters(index in 0usize..PALI_ALPHABET_ROMAN_COMPOUND_LETTERS_INDICES.len()) {
-            let indices: Vec<usize> = vec![0, PALI_ALPHABET_ROMAN_COMPOUND_LETTERS_INDICES[index], 39, 39, 3, 39];
+            let indices: Vec<usize> = vec![1, PALI_ALPHABET_ROMAN_COMPOUND_LETTERS_INDICES[index], 39, 39, 3, 39];
             let fixed_indices = fixup_compound_letters(&indices);
 
-            let new_indices = vec![0, PALI_ALPHABET_ROMAN_COMPOUND_LETTERS_INDICES[index] + 1, 39, 3, 39];
+            let new_indices = vec![1, PALI_ALPHABET_ROMAN_COMPOUND_LETTERS_INDICES[index] + 1, 39, 3, 39];
 
             assert_eq!(new_indices, fixed_indices)
         }

--- a/pls_core/src/alphabet.rs
+++ b/pls_core/src/alphabet.rs
@@ -231,16 +231,16 @@ mod tests {
 
     #[test]
     fn test_pali_alphabet_length() {
-        assert_eq!(PALI_ALPHABET_ROMAN.len(), 41);
+        assert_eq!(PALI_ALPHABET_ROMAN.len(), 42);
 
         let i: usize = PaliAlphabet::DotM.into();
-        assert_eq!(i, 40);
+        assert_eq!(i, 41);
     }
 
     const PALI_ALPHABET_ROMAN_COMPOUND_LETTERS_INDICES: &[usize] =
-        &[8, 10, 13, 15, 18, 20, 23, 25, 28, 30];
+        &[9, 11, 14, 16, 19, 21, 24, 26, 29, 31];
 
-    const PALI_ALPHABET_ROMAN_COMPOUNDING_LETTER_INDEX: usize = 38;
+    const PALI_ALPHABET_ROMAN_COMPOUNDING_LETTER_INDEX: usize = 39;
 
     fn is_compound_letter_roman(index: usize) -> bool {
         None != PALI_ALPHABET_ROMAN_COMPOUND_LETTERS_INDICES
@@ -317,6 +317,7 @@ mod tests {
     #[test_case("yabc", "xabc"  => -1)]
     #[test_case("i", "ā"    => 1; "random letters 1")]
     #[test_case("cc", "b"   => -1; "longer of lesser sort order 1")]
+    #[test_case("pālicca", "pāli 1"    => 1; "spaces 1")]
     fn string_compare_tests(str1: &str, str2: &str) -> isize {
         string_compare(str1, str2)
     }
@@ -342,10 +343,10 @@ mod tests {
 
         #[test]
         fn fixup_compound_letters_with_compound_letters(index in 0usize..PALI_ALPHABET_ROMAN_COMPOUND_LETTERS_INDICES.len()) {
-            let indices: Vec<usize> = vec![0, PALI_ALPHABET_ROMAN_COMPOUND_LETTERS_INDICES[index], 38, 38, 2, 38];
+            let indices: Vec<usize> = vec![0, PALI_ALPHABET_ROMAN_COMPOUND_LETTERS_INDICES[index], 39, 39, 3, 39];
             let fixed_indices = fixup_compound_letters(&indices);
 
-            let new_indices = vec![0, PALI_ALPHABET_ROMAN_COMPOUND_LETTERS_INDICES[index] + 1, 38, 2, 38];
+            let new_indices = vec![0, PALI_ALPHABET_ROMAN_COMPOUND_LETTERS_INDICES[index] + 1, 39, 3, 39];
 
             assert_eq!(new_indices, fixed_indices)
         }

--- a/pls_core/src/alphabet.rs
+++ b/pls_core/src/alphabet.rs
@@ -8,6 +8,7 @@ use std::{convert::TryFrom, iter::Peekable};
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, IntoPrimitive, TryFromPrimitive)]
 #[repr(usize)]
 pub enum PaliAlphabet {
+    Space,
     A,
     Aa,
     I,
@@ -15,51 +16,52 @@ pub enum PaliAlphabet {
     U,
     Uu,
     E,
-    O, // vowels - 0-7
+    O, // vowels - 1-8
     K,
     Kh,
     G,
     Gh,
-    QuoteN, // guttural - 8-12
+    QuoteN, // guttural - 9-13
     C,
     Ch,
     J,
     Jh,
-    TildeN, // palatal - 13-17
+    TildeN, // palatal - 14-18
     DotT,
     DotTh,
     DotD,
     DotDh,
-    DotN, // retroflex cerebral - 18-22
+    DotN, // retroflex cerebral - 19-23
     T,
     Th,
     D,
     Dh,
-    N, // dental - 23-27
+    N, // dental - 24-28
     P,
     Ph,
     B,
     Bh,
-    M, // labial - 28-32
+    M, // labial - 29-33
     Y,
     R,
     L,
     V,
     S,
     H,
-    DotL, // semi-vowel - 33-39
-    DotM, // nigahita - 40-40
+    DotL, // semi-vowel - 34-40
+    DotM, // nigahita - 41-41
 }
 
 pub const PALI_ALPHABET_ROMAN: &[&str] = &[
-    "a", "ā", "i", "ī", "u", "ū", "e", "o", // vowels - 0-7
-    "k", "kh", "g", "gh", "ṅ", // guttural - 8-12
-    "c", "ch", "j", "jh", "ñ", // palatal - 13-17
-    "ṭ", "ṭh", "ḍ", "ḍh", "ṇ", // retroflex cerebral - 18-22
-    "t", "th", "d", "dh", "n", // dental - 23-27
-    "p", "ph", "b", "bh", "m", // labial - 28-32
-    "y", "r", "l", "v", "s", "h", "ḷ", // semi-vowel - 33-39
-    "ṃ", // nigahita - 40-40
+    " ", // space - 0
+    "a", "ā", "i", "ī", "u", "ū", "e", "o", // vowels - 1-8
+    "k", "kh", "g", "gh", "ṅ", // guttural - 9-13
+    "c", "ch", "j", "jh", "ñ", // palatal - 14-18
+    "ṭ", "ṭh", "ḍ", "ḍh", "ṇ", // retroflex cerebral - 19-23
+    "t", "th", "d", "dh", "n", // dental - 24-28
+    "p", "ph", "b", "bh", "m", // labial - 29-33
+    "y", "r", "l", "v", "s", "h", "ḷ", // semi-vowel - 34-40
+    "ṃ", // nigahita - 41-41
 ];
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -142,6 +144,7 @@ impl<'a> Iterator for CharacterTokenizer<'a> {
 
     fn next(&mut self) -> Option<Character> {
         match self.source.next() {
+            Some(' ') => Some(parse_singlechar_letter(PaliAlphabet::Space)),
             Some('a') => Some(parse_singlechar_letter(PaliAlphabet::A)),
             Some('ā') => Some(parse_singlechar_letter(PaliAlphabet::Aa)),
             Some('i') => Some(parse_singlechar_letter(PaliAlphabet::I)),


### PR DESCRIPTION
Deals with item in [this](https://github.com/digitalpalitools/web-ui/issues/26) issue -
> in the drop-down list, change alphabetical order - space must comes before pāli letters, so short words come to the top of the list. at the moment the most common words are buried at the bottom of very long lists.