### PR TITLE
Changes feedback link text to avoid confusion. 

### DIFF
--- a/pls_core/src/inflections/snapshots/pls_core__inflections__tests__inflection_tests__conjugation_1_en.snap
+++ b/pls_core/src/inflections/snapshots/pls_core__inflections__tests__inflection_tests__conjugation_1_en.snap
@@ -258,7 +258,7 @@ expression: html
 
   <footer class="pls-inflection-footer">
     <a class="pls-inflection-feedback-link" target="_blank" href="https://docs.google.com/forms/d/e/1FAIpQLSeJpx7TsISkYEXzxvbBtOH25T-ZO1Z5NFdujO5SD9qcAH_i1A/viewform?entry.267696921=test case&entry.1433863141=v0.1">
-      spot a mistake? something missing? fix it here!
+      spot a mistake in the inflection table? something missing? fix it here!
     </a>
   </footer>
 </div>

--- a/pls_core/src/inflections/snapshots/pls_core__inflections__tests__inflection_tests__conjugation_1_xx.snap
+++ b/pls_core/src/inflections/snapshots/pls_core__inflections__tests__inflection_tests__conjugation_1_xx.snap
@@ -258,7 +258,7 @@ expression: html
 
   <footer class="pls-inflection-footer">
     <a class="pls-inflection-feedback-link" target="_blank" href="https://docs.google.com/forms/d/e/1FAIpQLSeJpx7TsISkYEXzxvbBtOH25T-ZO1Z5NFdujO5SD9qcAH_i1A/viewform?entry.267696921=test case&entry.1433863141=v0.1">
-      spot a mistake? something missing? fix it here!
+      spot a mistake in the inflection table? something missing? fix it here!
     </a>
   </footer>
 </div>

--- a/pls_core/src/inflections/snapshots/pls_core__inflections__tests__inflection_tests__declension_1_xx_.snap
+++ b/pls_core/src/inflections/snapshots/pls_core__inflections__tests__inflection_tests__declension_1_xx_.snap
@@ -133,7 +133,7 @@ expression: html
 
   <footer class="pls-inflection-footer">
     <a class="pls-inflection-feedback-link" target="_blank" href="https://docs.google.com/forms/d/e/1FAIpQLSeoxZiqvIWadaLeuXF4f44NCqEn49-B8KNbSvNer5jxgRYdtQ/viewform?entry.267696921=test case&entry.1433863141=v0.1">
-      spot a mistake? something missing? fix it here!
+      spot a mistake in the inflection table? something missing? fix it here!
     </a>
   </footer>
 </div>

--- a/pls_core/src/inflections/snapshots/pls_core__inflections__tests__inflection_tests__declension_2_irreg_xx.snap
+++ b/pls_core/src/inflections/snapshots/pls_core__inflections__tests__inflection_tests__declension_2_irreg_xx.snap
@@ -138,7 +138,7 @@ expression: html
 
   <footer class="pls-inflection-footer">
     <a class="pls-inflection-feedback-link" target="_blank" href="https://docs.google.com/forms/d/e/1FAIpQLSeoxZiqvIWadaLeuXF4f44NCqEn49-B8KNbSvNer5jxgRYdtQ/viewform?entry.267696921=test case&entry.1433863141=v0.1">
-      spot a mistake? something missing? fix it here!
+      spot a mistake in the inflection table? something missing? fix it here!
     </a>
   </footer>
 </div>

--- a/pls_core/src/inflections/snapshots/pls_core__inflections__tests__inflection_tests__declension_3_ind_xx.snap
+++ b/pls_core/src/inflections/snapshots/pls_core__inflections__tests__inflection_tests__declension_3_ind_xx.snap
@@ -25,7 +25,7 @@ expression: html
 
   <footer class="pls-inflection-footer">
     <a class="pls-inflection-feedback-link" target="_blank" href="https://docs.google.com/forms/d/e/1FAIpQLSeoxZiqvIWadaLeuXF4f44NCqEn49-B8KNbSvNer5jxgRYdtQ/viewform?entry.267696921=test case&entry.1433863141=v0.1">
-      spot a mistake? something missing? fix it here!
+      spot a mistake in the inflection table? something missing? fix it here!
     </a>
   </footer>
 </div>

--- a/pls_core/src/inflections/snapshots/pls_core__inflections__tests__inflection_tests__declension_4_pron_1st_xx.snap
+++ b/pls_core/src/inflections/snapshots/pls_core__inflections__tests__inflection_tests__declension_4_pron_1st_xx.snap
@@ -127,7 +127,7 @@ expression: html
 
   <footer class="pls-inflection-footer">
     <a class="pls-inflection-feedback-link" target="_blank" href="https://docs.google.com/forms/d/e/1FAIpQLSeoxZiqvIWadaLeuXF4f44NCqEn49-B8KNbSvNer5jxgRYdtQ/viewform?entry.267696921=test case&entry.1433863141=v0.1">
-      spot a mistake? something missing? fix it here!
+      spot a mistake in the inflection table? something missing? fix it here!
     </a>
   </footer>
 </div>

--- a/pls_core/src/inflections/snapshots/pls_core__inflections__tests__inflection_tests__declension_4_pron_2nd_xx.snap
+++ b/pls_core/src/inflections/snapshots/pls_core__inflections__tests__inflection_tests__declension_4_pron_2nd_xx.snap
@@ -125,7 +125,7 @@ expression: html
 
   <footer class="pls-inflection-footer">
     <a class="pls-inflection-feedback-link" target="_blank" href="https://docs.google.com/forms/d/e/1FAIpQLSeoxZiqvIWadaLeuXF4f44NCqEn49-B8KNbSvNer5jxgRYdtQ/viewform?entry.267696921=test case&entry.1433863141=v0.1">
-      spot a mistake? something missing? fix it here!
+      spot a mistake in the inflection table? something missing? fix it here!
     </a>
   </footer>
 </div>

--- a/pls_core/src/inflections/snapshots/pls_core__inflections__tests__inflection_tests__declension_4_pron_dual_xx.snap
+++ b/pls_core/src/inflections/snapshots/pls_core__inflections__tests__inflection_tests__declension_4_pron_dual_xx.snap
@@ -88,7 +88,7 @@ expression: html
 
   <footer class="pls-inflection-footer">
     <a class="pls-inflection-feedback-link" target="_blank" href="https://docs.google.com/forms/d/e/1FAIpQLSeoxZiqvIWadaLeuXF4f44NCqEn49-B8KNbSvNer5jxgRYdtQ/viewform?entry.267696921=test case&entry.1433863141=v0.1">
-      spot a mistake? something missing? fix it here!
+      spot a mistake in the inflection table? something missing? fix it here!
     </a>
   </footer>
 </div>

--- a/pls_core/src/inflections/snapshots/pls_core__inflections__tests__inflection_tests__declension_5_only_x_gender_xx.snap
+++ b/pls_core/src/inflections/snapshots/pls_core__inflections__tests__inflection_tests__declension_5_only_x_gender_xx.snap
@@ -117,7 +117,7 @@ expression: html
 
   <footer class="pls-inflection-footer">
     <a class="pls-inflection-feedback-link" target="_blank" href="https://docs.google.com/forms/d/e/1FAIpQLSeoxZiqvIWadaLeuXF4f44NCqEn49-B8KNbSvNer5jxgRYdtQ/viewform?entry.267696921=test case&entry.1433863141=v0.1">
-      spot a mistake? something missing? fix it here!
+      spot a mistake in the inflection table? something missing? fix it here!
     </a>
   </footer>
 </div>

--- a/pls_core/src/inflections/templates/output.html
+++ b/pls_core/src/inflections/templates/output.html
@@ -14,7 +14,7 @@
 {{ body }}
   <footer class="pls-inflection-footer">
     <a class="pls-inflection-feedback-link" target="_blank" href="{{ feedback_form_url }}?entry.267696921={{ host_url }}&entry.1433863141={{ host_version }}">
-      spot a mistake? something missing? fix it here!
+      spot a mistake in the inflection table? something missing? fix it here!
     </a>
   </footer>
 </div>


### PR DESCRIPTION
Deals with item in [this](https://github.com/digitalpalitools/web-ui/issues/26) issue -
> spot a mistake? update text to
spot a mistake in the inflection table? something missing? fix it here!
(to clearly differentiate it from dictionary feedback link)
users are already using the wrong link for inflection feedback 