### PR TITLE
Changes sorting order.

### DIFF
--- a/pls_core/src/alphabet.rs
+++ b/pls_core/src/alphabet.rs
@@ -314,6 +314,8 @@ mod tests {
     #[test_case("yabc", "xabc"  => -1)]
     #[test_case("i", "ā"    => 1; "random letters 1")]
     #[test_case("cc", "b"   => -1; "longer of lesser sort order 1")]
+    #[test_case("pāli 1", "pālicca"  => 1; "space case")]
+    #[test_case("pādesu sirasā nipatitvā", "pādesu 1" => -1; "number case") ]
     fn string_compare_tests(str1: &str, str2: &str) -> isize {
         string_compare(str1, str2)
     }

--- a/pls_core/src/alphabet.rs
+++ b/pls_core/src/alphabet.rs
@@ -64,8 +64,8 @@ pub const PALI_ALPHABET_ROMAN: &[&str] = &[
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum Character {
-    Pali(PaliAlphabet),
     Other(char),
+    Pali(PaliAlphabet),
 }
 
 pub struct CharacterTokenizer<'a> {


### PR DESCRIPTION
Non-Pali characters come first. Deals with item in [this](https://github.com/digitalpalitools/web-ui/issues/26) issue - 
>  in the drop-down list, change alphabetical order - space must comes before pāli letters, so short words come to the top of the list. at the moment the most common words are buried at the bottom of very long lists.